### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,12 +3,13 @@ Type: Package
 Title: Import and represent Xenium data from the 10X Xenium Analyzer
 Version: 1.3.2
 Authors@R: c(
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", c("aut", "cre"),
-        c(ORCID = "0000-0002-3242-0582")
-    ),
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-3242-0582")),
     person("Dario", "Righelli", role = "ctb"),
-    person("Estella", "Dong", role = "ctb")
-    )
+    person("Estella", "Dong", role = "ctb"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
+  )
 Description: The package allows users to readily import spatial data
     obtained from the 10X Xenium Analyzer pipeline. Supported formats include
     'parquet', 'h5', and 'mtx' files. The package mainly represents data

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,13 +3,12 @@ Type: Package
 Title: Import and represent Xenium data from the 10X Xenium Analyzer
 Version: 1.3.2
 Authors@R: c(
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0002-3242-0582")),
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", 
+        c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")),
     person("Dario", "Righelli", role = "ctb"),
     person("Estella", "Dong", role = "ctb"),
-    person("NCI", role = "fnd",
-           comment = c(GrantNo. = "U24CA289073"))
-  )
+    person("NCI", role = "fnd", comment = c(GrantNo. = "U24CA289073"))
+    )
 Description: The package allows users to readily import spatial data
     obtained from the 10X Xenium Analyzer pipeline. Supported formats include
     'parquet', 'h5', and 'mtx' files. The package mainly represents data

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Import and represent Xenium data from the 10X Xenium Analyzer
 Version: 1.3.2
 Authors@R: c(
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", 
-        c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")),
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", c("aut", "cre"),
+        c(ORCID = "0000-0002-3242-0582")),
     person("Dario", "Righelli", role = "ctb"),
     person("Estella", "Dong", role = "ctb"),
     person("NCI", role = "fnd", comment = c(GrantNo. = "U24CA289073"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Title: Import and represent Xenium data from the 10X Xenium Analyzer
 Version: 1.3.2
 Authors@R: c(
     person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", c("aut", "cre"),
-        c(ORCID = "0000-0002-3242-0582")),
+        c(ORCID = "0000-0002-3242-0582")
+    ),
     person("Dario", "Righelli", role = "ctb"),
     person("Estella", "Dong", role = "ctb"),
     person("NCI", role = "fnd", comment = c(GrantNo. = "U24CA289073"))


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23506340730](https://github.com/waldronlab/repo-audits/actions/runs/23506340730)).